### PR TITLE
Add setup script for quick environment spin-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ generate it inside the Docker container with Composer.
 - [Docker](https://docs.docker.com/get-docker/) (20+)
 - [Docker Compose](https://docs.docker.com/compose/) v2
 
+## Quick Start
+
+You can spin up the local environment with the provided `setup.sh` script. It
+builds the Docker images, installs the Symfony skeleton if needed and starts the
+services.
+
+```bash
+./setup.sh
+```
+
+This script performs the same actions as the manual steps listed below.
+
 ## Initial Setup
 
 1. Build the PHP container:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build the PHP image
+echo "Building Docker containers..."
+docker compose build
+
+# Install Symfony skeleton if not already installed
+if [ ! -f composer.json ]; then
+    echo "Installing Symfony skeleton..."
+    docker compose run --rm php composer create-project symfony/skeleton .
+fi
+
+# Start services in detached mode
+echo "Starting Docker services..."
+docker compose up -d
+
+echo "Environment is ready."
+echo "You can now run: docker compose exec php php -S 0.0.0.0:8000 -t public"


### PR DESCRIPTION
## Summary
- add `setup.sh` script to automate building the Docker environment and installing the Symfony skeleton
- document quick start steps using the new script

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6859619ffca88324b7fb9f446e0a7a80