### PR TITLE
Add setup script and update skeleton instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Symfony Docker Boilerplate
 
 This repository provides a minimal Docker setup for running a Symfony application
-with MySQL and PHP 8.4. The actual Symfony skeleton is not committed; you can
-generate it inside the Docker container with Composer.
+with MySQL and PHP 8.4. The actual Symfony skeleton is not committed; run the
+included `setup.sh` script inside the Docker container to install it
+automatically into the existing directory.
 
 ## Prerequisites
 
@@ -20,11 +21,11 @@ generate it inside the Docker container with Composer.
 2. Install the Symfony skeleton (run once):
 
    ```bash
-   docker compose run --rm php composer create-project symfony/skeleton .
+   docker compose run --rm php bash setup.sh
    ```
 
-   This command downloads the latest stable Symfony version into the current
-   directory.
+   The script downloads the latest Symfony skeleton into a temporary directory
+   and copies it into your project automatically.
 
 3. Start the services:
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+TARGET_DIR="/var/www/app"
+TEMP_DIR="/tmp/skeleton"
+
+# Create project in a temporary location
+rm -rf "$TEMP_DIR"
+composer create-project symfony/skeleton "$TEMP_DIR"
+
+# Copy generated files into the working directory
+cp -R "$TEMP_DIR"/. "$TARGET_DIR"
+
+# Cleanup temporary directory
+rm -rf "$TEMP_DIR"


### PR DESCRIPTION
## Summary
- include a `setup.sh` helper script for installing the Symfony skeleton
- update README instructions to reference the script and mention the temporary directory copy behavior

## Testing
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68596ec17dd883248006303714d56a0a